### PR TITLE
allow guzzlehttp/psr7 v2.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/psr7": "^1.6|^2.0",
         "guzzlehttp/guzzle": "^7.0",
         "brick/money": "^0.5.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3490b3c66d0581ef13151feb56bc1f3",
+    "content-hash": "77a352a58227411d51a641b3038d8856",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
# Description

- Allow both `v1.6` and `v2.0` on `guzzlehttp/psr7` dependency