### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+/.gitattributes         export-ignore
+/.editorconfig          export-ignore
+/.gitignore             export-ignore
+/.travis.yml            export-ignore
+/composer.lock          export-ignore
+/CODE_OF_CONDUCT.md     export-ignore
+/CONTRIBUTING.md        export-ignore
+/phpunit.xml.dist       export-ignore
+/docs                   export-ignore
+/tests                  export-ignore
+/.github                export-ignore
+
+*.php diff=php


### PR DESCRIPTION
Hi, 

The `.gitattributes` file will make the package smaller and will consume less space on hard disk.
This is recommended for php composer packages

https://php.watch/articles/composer-gitattributes

I would also suggest to remove all traces of `travis-ci` from repo as it is not working.